### PR TITLE
Add a placeholder test to make CI pass

### DIFF
--- a/tests/integration/test_harbor.py
+++ b/tests/integration/test_harbor.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+import logging
+import os
+
+pytest_plugins = ["k8s_test_harness.plugin"]
+
+LOG = logging.getLogger(__name__)
+
+
+def test_integration_place_holder():
+    # TODO: remove this placeholder test
+    # pytest fails if there is no test run
+    pass

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -40,7 +40,7 @@ commands =
     black {tox_root}/integration --check --diff
 
 [testenv:sanity]
-description = Run integration tests
+description = Run sanity tests
 deps =
     -r {tox_root}/requirements-test.txt
 commands =


### PR DESCRIPTION
Pytest fails if there is no test executed. Since we do not have any integration tests yet, I created a placeholder to make the CI happy (and let the ROCKs publish).

(also added a little naming drive-by fix)