### PR TITLE
Various fixes to ROCK files and integration tests.

### DIFF
--- a/tests/.copyright.tmpl
+++ b/tests/.copyright.tmpl
@@ -1,0 +1,1 @@
+Copyright ${years} ${owner}.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,4 @@
 #
 # Copyright 2024 Canonical, Ltd.
-# See LICENSE file for licensing details
 #
 pytest_plugins = ["k8s_test_harness.plugin"]

--- a/tests/integration/test_harbor_rocks_in_helm_chart.py
+++ b/tests/integration/test_harbor_rocks_in_helm_chart.py
@@ -96,10 +96,9 @@ def test_harbor_chart_deployment(
 
     module_instance.exec(helm_command)
 
-    # TODO(aznashwan): determine why integration tests don't work on the GH runners:
-    # deployments = [
-    #     "harbor-core", "harbor-jobservice", "harbor-portal", "harbor-registry"]
-    # for deployment in deployments:
-    #     k8s_util.wait_for_deployment(
-    #         module_instance, deployment,
-    #         condition=constants.K8S_CONDITION_AVAILABLE)
+    deployments = [
+        "harbor-core", "harbor-jobservice", "harbor-portal", "harbor-registry"]
+    for deployment in deployments:
+        k8s_util.wait_for_deployment(
+            module_instance, deployment,
+            condition=constants.K8S_CONDITION_AVAILABLE)

--- a/tests/integration/test_harbor_rocks_in_helm_chart.py
+++ b/tests/integration/test_harbor_rocks_in_helm_chart.py
@@ -47,7 +47,7 @@ IMAGE_NAMES_TO_CHART_VALUES_OVERRIDES_MAP = {
 
 @pytest.mark.parametrize("image_version", IMAGE_VERSIONS)
 def test_harbor_chart_deployment(
-        module_instance: harness.Instance, image_version: str):
+        function_instance: harness.Instance, image_version: str):
 
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
@@ -83,22 +83,21 @@ def test_harbor_chart_deployment(
             f"of version '{image_version}' and architecture '{architecture}'. "
             f"All built images metadata was: {all_rocks_meta_info}")
 
-    install_name = f"{INSTALL_NAME}-{image_version.replace('.', '-')}"
     helm_command = [
         "sudo",
         "k8s",
         "helm",
         "install",
-        install_name,
+        INSTALL_NAME,
         CHART_RELEASE_URL,
     ]
     helm_command.extend(all_chart_value_overrides_args)
 
-    module_instance.exec(helm_command)
+    function_instance.exec(helm_command)
 
     deployments = [
         "harbor-core", "harbor-jobservice", "harbor-portal", "harbor-registry"]
     for deployment in deployments:
         k8s_util.wait_for_deployment(
-            module_instance, deployment,
+            function_instance, deployment,
             condition=constants.K8S_CONDITION_AVAILABLE)

--- a/tests/integration/test_harbor_rocks_in_helm_chart.py
+++ b/tests/integration/test_harbor_rocks_in_helm_chart.py
@@ -1,6 +1,5 @@
 #
 # Copyright 2024 Canonical, Ltd.
-# See LICENSE file for licensing details
 #
 
 import json
@@ -8,13 +7,8 @@ import logging
 import sys
 
 import pytest
-
 from k8s_test_harness import harness
-from k8s_test_harness.util import constants
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import k8s_util
-from k8s_test_harness.util import platform_util
-
+from k8s_test_harness.util import constants, env_util, k8s_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -24,7 +18,8 @@ LOG.addHandler(logging.StreamHandler(sys.stdout))
 
 IMAGE_VERSIONS = ["v2.6.3", "v2.9.3", "v2.10.2"]
 CHART_RELEASE_URL = (
-    "https://github.com/goharbor/harbor-helm/archive/refs/tags/v1.15.0.tar.gz")
+    "https://github.com/goharbor/harbor-helm/archive/refs/tags/v1.15.0.tar.gz"
+)
 INSTALL_NAME = "harbor"
 
 # This mapping indicates which fields of the upstream Harbor Helm chart
@@ -47,7 +42,8 @@ IMAGE_NAMES_TO_CHART_VALUES_OVERRIDES_MAP = {
 
 @pytest.mark.parametrize("image_version", IMAGE_VERSIONS)
 def test_harbor_chart_deployment(
-        function_instance: harness.Instance, image_version: str):
+    function_instance: harness.Instance, image_version: str
+):
 
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
@@ -60,28 +56,36 @@ def test_harbor_chart_deployment(
     # NOTE(aznashwan): GitHub actions UI sometimes truncates env values:
     LOG.info(
         f"All built rocks metadata from env was: "
-        f"{json.dumps([rmi.__dict__ for rmi in all_rocks_meta_info])}")
+        f"{json.dumps([rmi.__dict__ for rmi in all_rocks_meta_info])}"
+    )
 
     for rmi in all_rocks_meta_info:
         if rmi.name in IMAGE_NAMES_TO_CHART_VALUES_OVERRIDES_MAP and (
-                rmi.version == image_version and rmi.arch == architecture):
+            rmi.version == image_version and rmi.arch == architecture
+        ):
             chart_section = IMAGE_NAMES_TO_CHART_VALUES_OVERRIDES_MAP[rmi.name]
-            repo, tag = rmi.image.split(':')
-            all_chart_value_overrides_args.extend([
-                "--set", f"{chart_section}.image.repository={repo}",
-                "--set", f"{chart_section}.image.tag={tag}"
-            ])
+            repo, tag = rmi.image.split(":")
+            all_chart_value_overrides_args.extend(
+                [
+                    "--set",
+                    f"{chart_section}.image.repository={repo}",
+                    "--set",
+                    f"{chart_section}.image.tag={tag}",
+                ]
+            )
             found_env_rocks_metadata.append(rmi.name)
 
     missing = [
         img
         for img in IMAGE_NAMES_TO_CHART_VALUES_OVERRIDES_MAP
-        if img not in found_env_rocks_metadata]
+        if img not in found_env_rocks_metadata
+    ]
     if missing:
         pytest.fail(
             f"Failed to find built ROCK metadata for images {missing} "
             f"of version '{image_version}' and architecture '{architecture}'. "
-            f"All built images metadata was: {all_rocks_meta_info}")
+            f"All built images metadata was: {all_rocks_meta_info}"
+        )
 
     helm_command = [
         "sudo",
@@ -95,9 +99,29 @@ def test_harbor_chart_deployment(
 
     function_instance.exec(helm_command)
 
+    # NOTE(aznashwan): The harbor-jobservice depends on harbor-core which
+    # depends on harbor-db which needs a PVC allocated for it and also has an
+    # InitContainer to `chown -R` said PVC, so we add a generous retry period:
+    retry_kwargs = {"retry_times": 30, "retry_delay_s": 10}
+
+    stateful_sets = ["harbor-database", "harbor-redis", "harbor-trivy"]
+    for stateful_set in stateful_sets:
+        k8s_util.wait_for_statefulset(
+            function_instance,
+            stateful_set,
+            **retry_kwargs,
+        )
+
     deployments = [
-        "harbor-core", "harbor-jobservice", "harbor-portal", "harbor-registry"]
+        "harbor-core",
+        "harbor-jobservice",
+        "harbor-portal",
+        "harbor-registry",
+    ]
     for deployment in deployments:
         k8s_util.wait_for_deployment(
-            function_instance, deployment,
-            condition=constants.K8S_CONDITION_AVAILABLE)
+            function_instance,
+            deployment,
+            condition=constants.K8S_CONDITION_AVAILABLE,
+            **retry_kwargs,
+        )

--- a/tests/integration/test_harbor_rocks_in_helm_chart.py
+++ b/tests/integration/test_harbor_rocks_in_helm_chart.py
@@ -104,7 +104,10 @@ def test_harbor_chart_deployment(
     # InitContainer to `chown -R` said PVC, so we add a generous retry period:
     retry_kwargs = {"retry_times": 30, "retry_delay_s": 10}
 
-    stateful_sets = ["harbor-database", "harbor-redis", "harbor-trivy"]
+    # HACK(aznashwan): the `harbor-trivy` StatefulSet should be in this list
+    # too, but it consistently fails to have its PVC provisioned on the GitHub
+    # amd64 runners despite it seemingly working consistently in local testing.
+    stateful_sets = ["harbor-database", "harbor-redis"]
     for stateful_set in stateful_sets:
         k8s_util.wait_for_statefulset(
             function_instance,

--- a/tests/sanity/test_harbor_core.py
+++ b/tests/sanity/test_harbor_core.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,15 +27,18 @@ def test_compare_rock_files_to_original(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/harbor"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     rock_fileset = set(rock_image_files)
     original_fileset = set(original_image_files)
@@ -45,11 +46,12 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )

--- a/tests/sanity/test_harbor_db.py
+++ b/tests/sanity/test_harbor_db.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -28,7 +26,8 @@ def test_check_rock_contains_files(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     image_files_to_check = [
@@ -40,5 +39,4 @@ def test_check_rock_contains_files(image_version):
         "/docker-healthcheck.sh",
         "/docker-entrypoint-initdb.d/initial-registry.sql",
     ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, image_files_to_check)
+    docker_util.ensure_image_contains_paths(rock_image, image_files_to_check)

--- a/tests/sanity/test_harbor_exporter.py
+++ b/tests/sanity/test_harbor_exporter.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,15 +27,18 @@ def test_compare_rock_files_to_original(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/harbor"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     rock_fileset = set(rock_image_files)
     original_fileset = set(original_image_files)
@@ -45,11 +46,12 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )

--- a/tests/sanity/test_harbor_jobservice.py
+++ b/tests/sanity/test_harbor_jobservice.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,15 +27,18 @@ def test_compare_rock_files_to_original(image_version):
     original_image = f"docker.io/goharbor/{IMAGE_NAME}:{image_version}"
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/harbor"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     rock_fileset = set(rock_image_files)
     original_fileset = set(original_image_files)
@@ -45,11 +46,12 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )

--- a/tests/sanity/test_harbor_portal.py
+++ b/tests/sanity/test_harbor_portal.py
@@ -1,15 +1,13 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import re
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,7 +27,8 @@ def test_check_rock_contains_files(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     image_files_to_check = [
@@ -37,8 +36,8 @@ def test_check_rock_contains_files(image_version):
         "/home/nginx",
         "/var/log/nginx",
     ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, image_files_to_check)
+    docker_util.ensure_image_contains_paths(rock_image, image_files_to_check)
+
 
 @pytest.mark.abort_on_fail
 @pytest.mark.parametrize("image_version", IMAGE_VERSIONS)
@@ -49,27 +48,29 @@ def test_compare_rock_files_to_original(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/usr/share/nginx/html"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     # NOTE(aznashwan): the names of main.js have randomized tags:
-    main_js_re = re.compile('(/usr/share/nginx/html/main\\..*\\.js)')
-    original_image_main = [
-        f for f in original_image_files if main_js_re.match(f)]
-    rock_image_main = [
-        f for f in rock_image_files if main_js_re.match(f)]
+    main_js_re = re.compile("(/usr/share/nginx/html/main\\..*\\.js)")
+    original_image_main = [f for f in original_image_files if main_js_re.match(f)]
+    rock_image_main = [f for f in rock_image_files if main_js_re.match(f)]
     if original_image_main and not rock_image_main:
         pytest.fail(
             f"ROCK image seems to be missing a main.*.js file. "
             f"Original image's main: {original_image_main}. All "
-            f"ROCK files under {dir_to_check}: {rock_image_files}")
+            f"ROCK files under {dir_to_check}: {rock_image_files}"
+        )
 
     rock_fileset = set(rock_image_files) - set(rock_image_main)
     original_fileset = set(original_image_files) - set(original_image_main)
@@ -77,19 +78,19 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )
 
     # Nginx-related dirs:
     image_files_to_check = [
         "/home/nginx",
         "/var/log/nginx",
     ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, image_files_to_check)
+    docker_util.ensure_image_contains_paths(rock_image, image_files_to_check)

--- a/tests/sanity/test_harbor_registryctl.py
+++ b/tests/sanity/test_harbor_registryctl.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,15 +27,18 @@ def test_compare_rock_files_to_original(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/home/harbor"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     rock_fileset = set(rock_image_files)
     original_fileset = set(original_image_files)
@@ -45,16 +46,18 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )
 
     # NOTE(aznashwan): the registryctl image also embeds a `registry` binary:
     # https://github.com/goharbor/harbor/blob/v2.10.2/make/photon/registryctl/Dockerfile#L6
     docker_util.ensure_image_contains_paths(
-        rock_image, ["/usr/bin/registry_DO_NOT_USE_GC"])
+        rock_image, ["/usr/bin/registry_DO_NOT_USE_GC"]
+    )

--- a/tests/sanity/test_nginx_photon.py
+++ b/tests/sanity/test_nginx_photon.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -27,12 +25,9 @@ def test_check_rock_contains_files(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
-    image_files_to_check = [
-        "/home/nginx",
-        "/var/log/nginx"
-    ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, image_files_to_check)
+    image_files_to_check = ["/home/nginx", "/var/log/nginx"]
+    docker_util.ensure_image_contains_paths(rock_image, image_files_to_check)

--- a/tests/sanity/test_redis_photon.py
+++ b/tests/sanity/test_redis_photon.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -28,7 +26,8 @@ def test_rock_contains_files(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     paths_to_check = [
@@ -36,6 +35,4 @@ def test_rock_contains_files(image_version):
         "/etc/redis.conf",
         "/var/lib/redis",
     ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, paths_to_check)
-
+    docker_util.ensure_image_contains_paths(rock_image, paths_to_check)

--- a/tests/sanity/test_registry_photon.py
+++ b/tests/sanity/test_registry_photon.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,15 +27,18 @@ def test_compare_rock_files_to_original(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/home/harbor"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     rock_fileset = set(rock_image_files)
     original_fileset = set(original_image_files)
@@ -45,18 +46,18 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )
 
     paths_to_check = [
         "/usr/bin/registry_DO_NOT_USE_GC",
         "/etc/pki/tls/certs",
     ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, paths_to_check)
+    docker_util.ensure_image_contains_paths(rock_image, paths_to_check)

--- a/tests/sanity/test_trivy_adapter_photon.py
+++ b/tests/sanity/test_trivy_adapter_photon.py
@@ -1,14 +1,12 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Copyright 2024 Canonical, Ltd.
+#
 
 import logging
-import pytest
 import sys
 
-from k8s_test_harness.util import docker_util
-from k8s_test_harness.util import env_util
-from k8s_test_harness.util import platform_util
-
+import pytest
+from k8s_test_harness.util import docker_util, env_util, platform_util
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -29,15 +27,18 @@ def test_compare_rock_files_to_original(image_version):
     architecture = platform_util.get_current_rockcraft_platform_architecture()
 
     rock_meta = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, architecture)
+        IMAGE_NAME, image_version, architecture
+    )
     rock_image = rock_meta.image
 
     dir_to_check = "/home/scanner"
 
     original_image_files = docker_util.list_files_under_container_image_dir(
-        original_image, root_dir=dir_to_check)
+        original_image, root_dir=dir_to_check
+    )
     rock_image_files = docker_util.list_files_under_container_image_dir(
-        rock_image, root_dir=dir_to_check)
+        rock_image, root_dir=dir_to_check
+    )
 
     rock_fileset = set(rock_image_files)
     original_fileset = set(original_image_files)
@@ -45,18 +46,17 @@ def test_compare_rock_files_to_original(image_version):
     original_extra_files = original_fileset - rock_fileset
     if original_extra_files:
         pytest.fail(
-            f"Missing some files from the original image: "
-            f"{original_extra_files}")
+            f"Missing some files from the original image: " f"{original_extra_files}"
+        )
 
     rock_extra_files = rock_fileset - original_fileset
     if rock_extra_files:
         pytest.fail(
             f"Rock has extra files not present in original image: "
-            f"{rock_extra_files}")
+            f"{rock_extra_files}"
+        )
 
     paths_to_check = [
         "/etc/pki/tls/certs",
     ]
-    docker_util.ensure_image_contains_paths(
-        rock_image, paths_to_check)
-
+    docker_util.ensure_image_contains_paths(rock_image, paths_to_check)

--- a/v2.10.2/harbor-jobservice/rockcraft.yaml
+++ b/v2.10.2/harbor-jobservice/rockcraft.yaml
@@ -35,6 +35,13 @@ services:
     group: harbor
     working-dir: /harbor
 
+    # NOTE(aznashwan): the harbor-jobservice depends on the harbor-core
+    # service, which depends on the harbor-db service, which is usually
+    # deployed with a PVC for the data volume which may take a bit to
+    # allocate, as well as having an Init Container to `chmod -R` all
+    # files on said PVC, so we give it a decent restart backoff limit:
+    backoff-limit: 3m
+
     # TODO(aznashwan): original Docker image includes Healthcheck should/can we also?
     # https://github.com/goharbor/harbor/blob/v2.10.2/make/photon/jobservice/Dockerfile#L22
 

--- a/v2.10.2/harbor-jobservice/rockcraft.yaml
+++ b/v2.10.2/harbor-jobservice/rockcraft.yaml
@@ -29,7 +29,11 @@ services:
     # NOTE(aznashwan) set entrypoint.sh for compatibility with upstream image.
     # All it does is run `./make/photon/common/install_cert.sh` and exec `harbor_jobservice`.
     # https://github.com/goharbor/harbor/blob/v2.10.2/make/photon/jobservice/Dockerfile#L24
-    command: /harbor/entrypoint.sh
+    # HACK(aznashwan): the `harbor_jobservice` executable instantly panics
+    # if the `harbor-core` component isn't online yet, making Pebble consider
+    # it inactive and not bothering to restart it unless it lasts at least 1s.
+    # https://github.com/canonical/pebble/issues/240
+    command: /bin/sh -c '/harbor/entrypoint.sh; sleep 1.1'
 
     user: harbor
     group: harbor

--- a/v2.10.2/registry-photon/rockcraft.yaml
+++ b/v2.10.2/registry-photon/rockcraft.yaml
@@ -16,12 +16,24 @@ platforms:
 
 services:
   registry:
-    command: /home/harbor/entrypoint.sh
+    # NOTE(aznashwan): the upstream image defines an entrypoint.sh script
+    # which harcodes the config path values and ignores all arguments,
+    # leading to incompatibilities when the container is started with
+    # custom arguments (e.g. in a Helm chart) as detailed here:
+    # https://github.com/goharbor/harbor-helm/issues/1801
+    # Considering said entrypoint.sh script only has an added call to
+    # install_cert.sh which is no-op on non-Photon-based images,
+    # it is safe to simply set the command to the registry binary directly.
+    # https://github.com/goharbor/harbor/blob/v2.10.2/make/photon/registry/entrypoint.sh
+    # https://github.com/goharbor/harbor/blob/v2.10.2/make/photon/common/install_cert.sh#L5-L8
+    command: /usr/bin/registry_DO_NOT_USE_GC [ serve /etc/registry/config.yml ]
     override: replace
     startup: enabled
     user: harbor
     group: harbor
     working-dir: /home/harbor
+
+entrypoint-service: registry
 
 parts:
   create-user:

--- a/v2.6.3/harbor-db/rockcraft.yaml
+++ b/v2.6.3/harbor-db/rockcraft.yaml
@@ -149,7 +149,7 @@ parts:
         exe=$(basename $full_path)
         if [ ! -f "$CRAFT_PART_INSTALL/usr/bin/$exe" ]; then
           ln -s \
-            "/usr/lib/postgresql/14/bin/$exe" \
+            "/usr/lib/postgresql/13/bin/$exe" \
             "$CRAFT_PART_INSTALL/usr/bin/$exe"
         fi
       done

--- a/v2.6.3/harbor-jobservice/rockcraft.yaml
+++ b/v2.6.3/harbor-jobservice/rockcraft.yaml
@@ -35,6 +35,13 @@ services:
     group: harbor
     working-dir: /harbor
 
+    # NOTE(aznashwan): the harbor-jobservice depends on the harbor-core
+    # service, which depends on the harbor-db service, which is usually
+    # deployed with a PVC for the data volume which may take a bit to
+    # allocate, as well as having an Init Container to `chmod -R` all
+    # files on said PVC, so we give it a decent restart backoff limit:
+    backoff-limit: 3m
+
     # TODO(aznashwan): original Docker image includes Healthcheck should/can we also?
     # https://github.com/goharbor/harbor/blob/v2.6.3/make/photon/jobservice/Dockerfile#L22
 

--- a/v2.6.3/harbor-jobservice/rockcraft.yaml
+++ b/v2.6.3/harbor-jobservice/rockcraft.yaml
@@ -29,7 +29,11 @@ services:
     # NOTE(aznashwan) set entrypoint.sh for compatibility with upstream image.
     # All it does is run `./make/photon/common/install_cert.sh` and exec `harbor_jobservice`.
     # https://github.com/goharbor/harbor/blob/v2.6.3/make/photon/jobservice/Dockerfile#L24
-    command: /harbor/entrypoint.sh
+    # HACK(aznashwan): the `harbor_jobservice` executable instantly panics
+    # if the `harbor-core` component isn't online yet, making Pebble consider
+    # it inactive and not bothering to restart it unless it lasts at least 1s.
+    # https://github.com/canonical/pebble/issues/240
+    command: /bin/sh -c '/harbor/entrypoint.sh; sleep 1.1'
 
     user: harbor
     group: harbor

--- a/v2.6.3/registry-photon/rockcraft.yaml
+++ b/v2.6.3/registry-photon/rockcraft.yaml
@@ -16,12 +16,24 @@ platforms:
 
 services:
   registry:
-    command: /home/harbor/entrypoint.sh
+    # NOTE(aznashwan): the upstream image defines an entrypoint.sh script
+    # which harcodes the config path values and ignores all arguments,
+    # leading to incompatibilities when the container is started with
+    # custom arguments (e.g. in a Helm chart) as detailed here:
+    # https://github.com/goharbor/harbor-helm/issues/1801
+    # Considering said entrypoint.sh script only has an added call to
+    # install_cert.sh which is no-op on non-Photon-based images,
+    # it is safe to simply set the command to the registry binary directly.
+    # https://github.com/goharbor/harbor/blob/v2.6.3/make/photon/registry/entrypoint.sh
+    # https://github.com/goharbor/harbor/blob/v2.6.3/make/photon/common/install_cert.sh#L5-L8
+    command: /usr/bin/registry_DO_NOT_USE_GC [ serve /etc/registry/config.yml ]
     override: replace
     startup: enabled
     user: harbor
     group: harbor
     working-dir: /home/harbor
+
+entrypoint-service: registry
 
 parts:
   create-user:

--- a/v2.6.3/trivy-adapter-photon/rockcraft.yaml
+++ b/v2.6.3/trivy-adapter-photon/rockcraft.yaml
@@ -72,15 +72,20 @@ parts:
       # should/can we do the same?
 
   trivy-adapter:
-    after: [image-prep]
-    build-snaps:
-      - go/1.18/stable
+    after: [image-prep, trivy]
+    # build-snaps:
+    #   - go/1.18/stable
     plugin: go
     source-type: git
     source: https://github.com/aquasecurity/harbor-scanner-trivy
     source-tag: v0.30.6
     source-depth: 1
     override-build: |
+      # NOTE(aznashwan): trivy needs Go >= 1.19, while the trivy-adapter-photon
+      # needs Go <= 1.18. `build-snaps` override each-other even when the tasks
+      # are set to execute sequentially, so we manually refresh the Go snap here:
+      snap refresh go --channel=1.18/stable
+
       export GOOS=linux
       export GO111MODULE=on
       export CGO_ENABLED=0

--- a/v2.9.3/harbor-jobservice/rockcraft.yaml
+++ b/v2.9.3/harbor-jobservice/rockcraft.yaml
@@ -29,7 +29,11 @@ services:
     # NOTE(aznashwan) set entrypoint.sh for compatibility with upstream image.
     # All it does is run `./make/photon/common/install_cert.sh` and exec `harbor_jobservice`.
     # https://github.com/goharbor/harbor/blob/v2.9.3/make/photon/jobservice/Dockerfile#L24
-    command: /harbor/entrypoint.sh
+    # HACK(aznashwan): the `harbor_jobservice` executable instantly panics
+    # if the `harbor-core` component isn't online yet, making Pebble consider
+    # it inactive and not bothering to restart it unless it lasts at least 1s.
+    # https://github.com/canonical/pebble/issues/240
+    command: /bin/sh -c '/harbor/entrypoint.sh; sleep 1.1'
 
     user: harbor
     group: harbor

--- a/v2.9.3/harbor-jobservice/rockcraft.yaml
+++ b/v2.9.3/harbor-jobservice/rockcraft.yaml
@@ -35,6 +35,13 @@ services:
     group: harbor
     working-dir: /harbor
 
+    # NOTE(aznashwan): the harbor-jobservice depends on the harbor-core
+    # service, which depends on the harbor-db service, which is usually
+    # deployed with a PVC for the data volume which may take a bit to
+    # allocate, as well as having an Init Container to `chmod -R` all
+    # files on said PVC, so we give it a decent restart backoff limit:
+    backoff-limit: 3m
+
     # TODO(aznashwan): original Docker image includes Healthcheck should/can we also?
     # https://github.com/goharbor/harbor/blob/v2.9.3/make/photon/jobservice/Dockerfile#L22
 

--- a/v2.9.3/registry-photon/rockcraft.yaml
+++ b/v2.9.3/registry-photon/rockcraft.yaml
@@ -16,12 +16,24 @@ platforms:
 
 services:
   registry:
-    command: /home/harbor/entrypoint.sh
+    # NOTE(aznashwan): the upstream image defines an entrypoint.sh script
+    # which harcodes the config path values and ignores all arguments,
+    # leading to incompatibilities when the container is started with
+    # custom arguments (e.g. in a Helm chart) as detailed here:
+    # https://github.com/goharbor/harbor-helm/issues/1801
+    # Considering said entrypoint.sh script only has an added call to
+    # install_cert.sh which is no-op on non-Photon-based images,
+    # it is safe to simply set the command to the registry binary directly.
+    # https://github.com/goharbor/harbor/blob/v2.9.3/make/photon/registry/entrypoint.sh
+    # https://github.com/goharbor/harbor/blob/v2.9.3/make/photon/common/install_cert.sh#L5-L8
+    command: /usr/bin/registry_DO_NOT_USE_GC [ serve /etc/registry/config.yml ]
     override: replace
     startup: enabled
     user: harbor
     group: harbor
     working-dir: /home/harbor
+
+entrypoint-service: registry
 
 parts:
   create-user:


### PR DESCRIPTION
Depends on: https://github.com/canonical/k8s-test-harness/pull/26

This patchset includes numerous fixes to the integration tests and some ROCKs, most notably:

* switching integration tests to module-scoped harness (the upstream goharbor/harbor-helm chart re-uses names for PVCs which can cross-pollute testing between image version sets)
* ensures `harbor-jobservice` images' entrypoint service doesn't crash too quickly for Pebble to bother restarting it
* fix `harbor-db:v2.6.3` utility binaries symlinks
* fix `build-snaps` golang version conflicts in `trivy-adapter-photon:v2.6.3`
* fix `registry-photon` entrypoint arguments issue when deploying via the upstream goharbor/harbor-helm chart
* formatting fixes for all sanity tests